### PR TITLE
Check for QUEST context and open corresponding README file

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -31,7 +31,7 @@ tasks:
       cargo build --package soroban-hello-world-contract --target wasm32-unknown-unknown --release
       cargo test --package soroban-hello-world-contract
     command: |
-      if [ -z ${QUEST+x} ]; then cd quests/${QUEST}*; fi
+      if [[ ${QUEST} ]]; then cd quests/${QUEST}*; fi
       gp open README.md
       clear
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -31,8 +31,12 @@ tasks:
       cargo build --package soroban-hello-world-contract --target wasm32-unknown-unknown --release
       cargo test --package soroban-hello-world-contract
     command: |
-      if [[ ${QUEST} ]]; then cd quests/${QUEST}*; fi
-      gp open README.md
+      if [[ ${QUEST} ]]
+      then
+        gp open quests/${QUEST}*/README.md
+      else
+        gp open README.md
+      fi
       clear
 
 vscode:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -31,6 +31,7 @@ tasks:
       cargo build --package soroban-hello-world-contract --target wasm32-unknown-unknown --release
       cargo test --package soroban-hello-world-contract
     command: |
+      if [ -z ${QUEST+x} ]; then cd quests/${QUEST}*; fi
       gp open README.md
       clear
 


### PR DESCRIPTION
This checks first if the `QUEST` environment variable is set, and if it is changes into the relevant quest directory. Otherwise, it opens the top-level README, just like it's always done.

We will need to incorporate this change onto the frontend site so that it includes the `QUEST` context to gitpod, too.

<a href="https://gitpod.io/#https://github.com/stellar/soroban-quest/pull/9"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

